### PR TITLE
refactor: single-source username + collapse agenix secret boilerplate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -146,6 +146,10 @@
       system,
       isNotebook,
       primaryCompositor ? "niri",
+      # Primary local-account username. Single source of truth: threaded into
+      # both the NixOS modules (via specialArgs) and the home-manager user
+      # module, which mirrors it into home.username/homeDirectory.
+      username ? "kronberger",
       extraModules ? [],
       # The home-manager user module. Defaults to the full workstation user;
       # lean hosts (e.g. mediaBox) pass a trimmed one.
@@ -155,7 +159,7 @@
         inherit system;
         specialArgs = {
           host = hostname;
-          inherit isNotebook inputs primaryCompositor;
+          inherit isNotebook inputs primaryCompositor username;
         };
         modules =
           [
@@ -263,6 +267,7 @@
         system = x86System;
         specialArgs = {
           host = "homeserver";
+          username = "kronberger";
           inherit inputs;
           arrabbiata = inputs.arrabbiata.packages.${x86System}.default;
         };
@@ -314,6 +319,7 @@
         system = x86System;
         isNotebook = true;
         primaryCompositor = "niri";
+        username = "media";
         userModule = ./modules/home-manager/users/media.nix;
       };
     };

--- a/hosts/homeserver/configuration.nix
+++ b/hosts/homeserver/configuration.nix
@@ -1,4 +1,11 @@
-{pkgs, lib, arrabbiata, inputs, ...}: {
+{
+  pkgs,
+  lib,
+  arrabbiata,
+  inputs,
+  username,
+  ...
+}: {
   imports = [
     ./hardware-configuration.nix
     ../../modules/system/core/nix-settings.nix
@@ -53,7 +60,7 @@
   };
 
   # Users
-  users.users.kronberger = {
+  users.users.${username} = {
     createHome = true;
     isNormalUser = true;
     extraGroups = ["wheel"];
@@ -117,7 +124,7 @@
       LoginGraceTime = 30;
 
       # Only allow specific users
-      AllowUsers = ["kronberger" "wiesinger"];
+      AllowUsers = [username "wiesinger"];
     };
 
     # Strong ciphers and key exchange
@@ -212,7 +219,7 @@
   security.sudo-rs = {
     enable = true;
     extraRules = [{
-      users = ["kronberger"];
+      users = [username];
       commands = [{
         command = "ALL";
         options = ["NOPASSWD"];

--- a/hosts/intelNuc/configuration.nix
+++ b/hosts/intelNuc/configuration.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  username,
+  ...
+}: {
   imports = [
     ./hardware-configuration.nix
     ../common.nix
@@ -112,7 +116,7 @@
     max-jobs = 2; # Max parallel derivation builds
   };
 
-  users.users.kronberger.extraGroups = ["docker" "gamemode"];
+  users.users.${username}.extraGroups = ["docker" "gamemode"];
 
   system.stateVersion = "24.11";
 }

--- a/hosts/portable/configuration.nix
+++ b/hosts/portable/configuration.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  username,
+  ...
+}: {
   imports = [
     ./hardware-configuration.nix
     ../common.nix
@@ -33,7 +37,7 @@
   };
 
   systemd.tmpfiles.rules = [
-    "d /mnt/data 0755 kronberger users - -"
+    "d /mnt/data 0755 ${username} users - -"
   ];
 
   environment.systemPackages = with pkgs; [

--- a/hosts/spectre/configuration.nix
+++ b/hosts/spectre/configuration.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   config,
+  username,
   ...
 }: {
   imports = [
@@ -128,7 +129,7 @@
     max-jobs = 2; # Max parallel derivation builds
   };
 
-  users.users.kronberger.extraGroups = ["docker"];
+  users.users.${username}.extraGroups = ["docker"];
 
   environment.systemPackages = with pkgs; [
     brightnessctl

--- a/modules/home-manager/apps/taskwarrior.nix
+++ b/modules/home-manager/apps/taskwarrior.nix
@@ -1,11 +1,15 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  config,
+  ...
+}: {
   home.packages = with pkgs; [
     taskwarrior-tui
   ];
   programs.taskwarrior = {
     enable = true;
     package = pkgs.taskwarrior3;
-    dataLocation = "/home/kronberger/Documents/tasks";
+    dataLocation = "${config.home.homeDirectory}/Documents/tasks";
     config = {};
   };
 }

--- a/modules/home-manager/apps/yazi.nix
+++ b/modules/home-manager/apps/yazi.nix
@@ -5,7 +5,7 @@
 }: let
   mkSymlink = path:
     config.lib.file.mkOutOfStoreSymlink
-    "/home/kronberger/.config/nixos/${path}";
+    "${config.home.homeDirectory}/.config/nixos/${path}";
 in {
   xdg.configFile."yazi/flavors/base16-transparent.yazi/flavor.toml".source =
     mkSymlink "modules/home-manager/apps/yazi/base16-transparent.toml";
@@ -87,7 +87,7 @@ in {
         }
         {
           on = ["g" "u"];
-          run = "cd /run/media/kronberger";
+          run = "cd /run/media/${config.home.username}";
           desc = "Go to USB/removable media";
         }
       ];

--- a/modules/home-manager/editors/helix.nix
+++ b/modules/home-manager/editors/helix.nix
@@ -75,7 +75,7 @@ in {
   options.helix = {
     liveConfigPath = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
-      default = "/home/kronberger/.config/nixos";
+      default = "${config.home.homeDirectory}/.config/nixos";
       description = ''
         Path to a live checkout of this nixos repo. When set, helix's editable
         config files are out-of-store symlinks into it (edit without rebuild).

--- a/modules/home-manager/users/kronberger-server.nix
+++ b/modules/home-manager/users/kronberger-server.nix
@@ -1,10 +1,15 @@
-{pkgs, inputs, ...}: {
+{
+  pkgs,
+  inputs,
+  username,
+  ...
+}: {
   home-manager = {
     extraSpecialArgs = {inherit inputs;};
     useGlobalPkgs = true;
     useUserPackages = true;
     backupFileExtension = "backup";
-    users.kronberger = {
+    users.${username} = {
       imports = [
         ../shell/nushell.nix
         ../shell/git.nix
@@ -12,8 +17,8 @@
       ];
 
       home = {
-        username = "kronberger";
-        homeDirectory = "/home/kronberger";
+        inherit username;
+        homeDirectory = "/home/${username}";
         stateVersion = "25.05";
       };
 

--- a/modules/home-manager/users/kronberger.nix
+++ b/modules/home-manager/users/kronberger.nix
@@ -4,6 +4,7 @@
   host,
   isNotebook,
   primaryCompositor,
+  username,
   ...
 }: let
   dropkittenPkg = inputs.dropkitten.packages.${pkgs.stdenv.hostPlatform.system}.dropkitten;
@@ -15,7 +16,7 @@ in {
     useGlobalPkgs = true;
     useUserPackages = true;
     backupFileExtension = "backup-$(date +%Y%m%d-%H%M%S)";
-    users.kronberger = {
+    users.${username} = {
       imports = [
         ../.
       ];
@@ -52,8 +53,8 @@ in {
       };
 
       home = {
-        username = "kronberger";
-        homeDirectory = "/home/kronberger";
+        inherit username;
+        homeDirectory = "/home/${username}";
         packages = with pkgs; [
           dropkittenPkg
           nemo-with-extensions

--- a/modules/system/core/nix-settings.nix
+++ b/modules/system/core/nix-settings.nix
@@ -1,4 +1,8 @@
-{lib, ...}: {
+{
+  lib,
+  username,
+  ...
+}: {
   imports = [./nix-caches.nix];
 
   nix = {
@@ -18,8 +22,8 @@
 
       # Security
       sandbox = true;
-      allowed-users = ["root" "kronberger"];
-      trusted-users = ["root" "kronberger"];
+      allowed-users = ["root" username];
+      trusted-users = ["root" username];
 
       # nh handles dirty tree warnings
       warn-dirty = false;
@@ -27,7 +31,7 @@
     buildMachines = [
       {
         hostName = "homeserver";
-        sshUser = "kronberger";
+        sshUser = username;
         sshKey = "/root/.ssh/nix-builder";
         system = "x86_64-linux";
         maxJobs = 12;

--- a/modules/system/core/users.nix
+++ b/modules/system/core/users.nix
@@ -1,5 +1,10 @@
-{pkgs, config, ...}: {
-  users.users.kronberger = {
+{
+  pkgs,
+  config,
+  username,
+  ...
+}: {
+  users.users.${username} = {
     createHome = true;
     isNormalUser = true;
     hashedPasswordFile = config.age.secrets.kronberger-password.path;

--- a/modules/system/networking/pia.nix
+++ b/modules/system/networking/pia.nix
@@ -3,6 +3,7 @@
   config,
   inputs,
   lib,
+  username,
   ...
 }: let
   cfg = config.services.pia;
@@ -37,10 +38,10 @@ in {
     # Don't auto-start on boot (matching previous behavior)
     systemd.services.pia-vpn.wantedBy = lib.mkForce [];
 
-    # Allow kronberger to start/stop PIA via sudo
+    # Allow the primary user to start/stop PIA via sudo
     security.sudo-rs.extraRules = [
       {
-        users = ["kronberger"];
+        users = [username];
         commands = [
           {
             command = "/run/current-system/sw/bin/systemctl start pia-vpn.service";

--- a/modules/system/networking/tuwien-vpn.nix
+++ b/modules/system/networking/tuwien-vpn.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  username,
   ...
 }: let
   cfg = config.services.tuwien-vpn;
@@ -98,7 +99,7 @@ in {
     # Add sudo rules for VPN control
     security.sudo-rs.extraRules = [
       {
-        users = ["kronberger"];
+        users = [username];
         commands = [
           {
             command = "/run/current-system/sw/bin/systemctl start openconnect-tuwien.service";
@@ -121,7 +122,7 @@ in {
       polkit.addRule(function(action, subject) {
           if ((action.id == "org.freedesktop.systemd1.manage-units" &&
                action.lookup("unit") == "openconnect-tuwien.service") &&
-              subject.user == "kronberger") {
+              subject.user == "${username}") {
               return polkit.Result.YES;
           }
       });

--- a/modules/system/security/agenix.nix
+++ b/modules/system/security/agenix.nix
@@ -1,4 +1,8 @@
-{inputs, ...}: {
+{
+  inputs,
+  username,
+  ...
+}: {
   # Enable SSH for agenix
   services.openssh = {
     enable = true;
@@ -43,7 +47,7 @@
       file = "${inputs.self}/secrets/github-token.age";
       path = "/run/secrets/github-token";
       mode = "0400";
-      owner = "kronberger";
+      owner = username;
     };
 
     # Format: TUNET_USERNAME=e12202316@student.tuwien.ac.at\nTUNET_PASSWORD=your_password
@@ -58,7 +62,7 @@
       file = "${inputs.self}/secrets/spotify-password.age";
       path = "/run/secrets/spotify-password";
       mode = "0400";
-      owner = "kronberger";
+      owner = username;
     };
 
     # Single-line SFTP password, read by the sftp-mount nushell helper
@@ -66,7 +70,7 @@
       file = "${inputs.self}/secrets/sftp-password.age";
       path = "/run/secrets/sftp-password";
       mode = "0400";
-      owner = "kronberger";
+      owner = username;
     };
 
     # aerc mail passwords, read via *-cred-cmd (cat) in apps/aerc.nix
@@ -74,14 +78,14 @@
       file = "${inputs.self}/secrets/aerc-gmx-password.age";
       path = "/run/secrets/aerc-gmx-password";
       mode = "0400";
-      owner = "kronberger";
+      owner = username;
     };
 
     aerc-uptudate-password = {
       file = "${inputs.self}/secrets/aerc-uptudate-password.age";
       path = "/run/secrets/aerc-uptudate-password";
       mode = "0400";
-      owner = "kronberger";
+      owner = username;
     };
 
   };

--- a/modules/system/security/agenix.nix
+++ b/modules/system/security/agenix.nix
@@ -1,8 +1,37 @@
 {
   inputs,
   username,
+  lib,
   ...
-}: {
+}: let
+  # Every secret has the same shape: an age file in ./secrets, decrypted to
+  # /run/secrets/<name> with mode 0400. Only the owner varies (root vs the
+  # primary user), so list the names and let mkSecret fill in the rest.
+  mkSecret = owner: name: {
+    file = "${inputs.self}/secrets/${name}.age";
+    path = "/run/secrets/${name}";
+    mode = "0400";
+    inherit owner;
+  };
+
+  # Decrypted for root (consumed by system services / login).
+  rootSecrets = [
+    "kronberger-password" # hashed password for user login
+    "pia-credentials" # PIA_USER=pXXXXXXX\nPIA_PASS=your_password
+    "tuwien-vpn-password"
+    "tuwien-vpn-totp"
+    "tunet-credentials" # TUNET_USERNAME=e12202316@student.tuwien.ac.at\nTUNET_PASSWORD=your_password
+  ];
+
+  # Decrypted for the primary user (read directly from their session/tools).
+  userSecrets = [
+    "github-token"
+    "spotify-password"
+    "sftp-password" # single-line SFTP password, read by the sftp-mount nushell helper
+    "aerc-gmx-password" # aerc mail passwords, read via *-cred-cmd (cat) in apps/aerc.nix
+    "aerc-uptudate-password"
+  ];
+in {
   # Enable SSH for agenix
   services.openssh = {
     enable = true;
@@ -12,81 +41,7 @@
     };
   };
 
-  age.secrets = {
-    # Hashed password for user login
-    kronberger-password = {
-      file = "${inputs.self}/secrets/kronberger-password.age";
-      path = "/run/secrets/kronberger-password";
-      mode = "0400";
-      owner = "root";
-    };
-
-    # Format: PIA_USER=pXXXXXXX\nPIA_PASS=your_password
-    pia-credentials = {
-      file = "${inputs.self}/secrets/pia-credentials.age";
-      path = "/run/secrets/pia-credentials";
-      mode = "0400";
-      owner = "root";
-    };
-
-    tuwien-vpn-password = {
-      file = "${inputs.self}/secrets/tuwien-vpn-password.age";
-      path = "/run/secrets/tuwien-vpn-password";
-      mode = "0400";
-      owner = "root";
-    };
-
-    tuwien-vpn-totp = {
-      file = "${inputs.self}/secrets/tuwien-vpn-totp.age";
-      path = "/run/secrets/tuwien-vpn-totp";
-      mode = "0400";
-      owner = "root";
-    };
-
-    github-token = {
-      file = "${inputs.self}/secrets/github-token.age";
-      path = "/run/secrets/github-token";
-      mode = "0400";
-      owner = username;
-    };
-
-    # Format: TUNET_USERNAME=e12202316@student.tuwien.ac.at\nTUNET_PASSWORD=your_password
-    tunet-credentials = {
-      file = "${inputs.self}/secrets/tunet-credentials.age";
-      path = "/run/secrets/tunet-credentials";
-      mode = "0400";
-      owner = "root";
-    };
-
-    spotify-password = {
-      file = "${inputs.self}/secrets/spotify-password.age";
-      path = "/run/secrets/spotify-password";
-      mode = "0400";
-      owner = username;
-    };
-
-    # Single-line SFTP password, read by the sftp-mount nushell helper
-    sftp-password = {
-      file = "${inputs.self}/secrets/sftp-password.age";
-      path = "/run/secrets/sftp-password";
-      mode = "0400";
-      owner = username;
-    };
-
-    # aerc mail passwords, read via *-cred-cmd (cat) in apps/aerc.nix
-    aerc-gmx-password = {
-      file = "${inputs.self}/secrets/aerc-gmx-password.age";
-      path = "/run/secrets/aerc-gmx-password";
-      mode = "0400";
-      owner = username;
-    };
-
-    aerc-uptudate-password = {
-      file = "${inputs.self}/secrets/aerc-uptudate-password.age";
-      path = "/run/secrets/aerc-uptudate-password";
-      mode = "0400";
-      owner = username;
-    };
-
-  };
+  age.secrets =
+    lib.genAttrs rootSecrets (mkSecret "root")
+    // lib.genAttrs userSecrets (mkSecret username);
 }

--- a/modules/system/security/security.nix
+++ b/modules/system/security/security.nix
@@ -1,4 +1,9 @@
-{pkgs, lib, ...}: {
+{
+  pkgs,
+  lib,
+  username,
+  ...
+}: {
   # Enhanced firewall configuration
   networking.firewall = {
     enable = true;
@@ -90,7 +95,7 @@
         LoginGraceTime = 30;
 
         # Only allow specific users
-        AllowUsers = ["kronberger"];
+        AllowUsers = [username];
       };
 
       # Use strong key exchange algorithms

--- a/modules/system/services/syncthing.nix
+++ b/modules/system/services/syncthing.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   host,
+  username,
   ...
 }: let
   syncDevices = import ../../shared/syncthing-devices.nix;
@@ -26,12 +27,12 @@ in
   lib.mkIf enabled {
     services.syncthing = {
       enable = true;
-      user = "kronberger";
-      dataDir = "/home/kronberger";
-      configDir = "/home/kronberger/.config/syncthing";
+      user = username;
+      dataDir = "/home/${username}";
+      configDir = "/home/${username}/.config/syncthing";
 
       # Localhost only — access remote UIs via SSH tunnel:
-      # ssh -L 8384:127.0.0.1:8384 kronberger@<host>
+      # ssh -L 8384:127.0.0.1:8384 <user>@<host>
       guiAddress = "127.0.0.1:8384";
 
       # Let Nix manage devices; allow adding folders via UI too
@@ -44,7 +45,7 @@ in
         folders = {
           # Documents — synced across all NixOS machines
           "documents" = {
-            path = "/home/kronberger/Documents";
+            path = "/home/${username}/Documents";
             devices = builtins.attrNames otherDevices;
             versioning = {
               type = "staggered";
@@ -57,7 +58,7 @@ in
 
           # Obsidian vault — synced to phone too
           "general-vault" = {
-            path = "/home/kronberger/Documents/notes/general-vault";
+            path = "/home/${username}/Documents/notes/general-vault";
             devices = builtins.attrNames otherDevices ++ builtins.attrNames mobileDevices;
             versioning = {
               type = "staggered";
@@ -79,7 +80,7 @@ in
     };
 
     systemd.tmpfiles.rules = [
-      "L+ /home/kronberger/Documents/.stignore - - - - ${documentsIgnore}"
+      "L+ /home/${username}/Documents/.stignore - - - - ${documentsIgnore}"
     ];
 
     # Open firewall for Syncthing

--- a/modules/system/services/syncthing.nix
+++ b/modules/system/services/syncthing.nix
@@ -1,12 +1,17 @@
 {
   lib,
   pkgs,
+  config,
   host,
   username,
   ...
 }: let
   syncDevices = import ../../shared/syncthing-devices.nix;
   inherit (syncDevices) devices mobileDevices;
+
+  # The user's home, taken from the NixOS account definition rather than
+  # rebuilt from a string, so it tracks any users.users.<name>.home override.
+  homeDir = config.users.users.${username}.home;
 
   # Only enable on hosts that are in the devices list
   enabled = builtins.hasAttr host devices;
@@ -28,8 +33,8 @@ in
     services.syncthing = {
       enable = true;
       user = username;
-      dataDir = "/home/${username}";
-      configDir = "/home/${username}/.config/syncthing";
+      dataDir = homeDir;
+      configDir = "${homeDir}/.config/syncthing";
 
       # Localhost only — access remote UIs via SSH tunnel:
       # ssh -L 8384:127.0.0.1:8384 <user>@<host>
@@ -45,7 +50,7 @@ in
         folders = {
           # Documents — synced across all NixOS machines
           "documents" = {
-            path = "/home/${username}/Documents";
+            path = "${homeDir}/Documents";
             devices = builtins.attrNames otherDevices;
             versioning = {
               type = "staggered";
@@ -58,7 +63,7 @@ in
 
           # Obsidian vault — synced to phone too
           "general-vault" = {
-            path = "/home/${username}/Documents/notes/general-vault";
+            path = "${homeDir}/Documents/notes/general-vault";
             devices = builtins.attrNames otherDevices ++ builtins.attrNames mobileDevices;
             versioning = {
               type = "staggered";
@@ -80,7 +85,7 @@ in
     };
 
     systemd.tmpfiles.rules = [
-      "L+ /home/${username}/Documents/.stignore - - - - ${documentsIgnore}"
+      "L+ ${homeDir}/Documents/.stignore - - - - ${documentsIgnore}"
     ];
 
     # Open firewall for Syncthing

--- a/modules/system/services/virtualisation.nix
+++ b/modules/system/services/virtualisation.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  username,
+  ...
+}: {
   # Install QuickEMU and related packages
   environment.systemPackages = with pkgs; [
     quickemu
@@ -33,5 +37,5 @@
   programs.virt-manager.enable = true;
 
   # Add virtualisation groups to the user (graphics configured in desktop.nix)
-  users.users.kronberger.extraGroups = ["libvirtd" "kvm" "qemu-libvirtd" "render"];
+  users.users.${username}.extraGroups = ["libvirtd" "kvm" "qemu-libvirtd" "render"];
 }


### PR DESCRIPTION
Two related cleanups from a config review. Both are mechanical, behavior-preserving refactors.

---

## 1. Thread `username` as a single source of truth

Replaces the hardcoded `kronberger` **local-account identity** (previously repeated across ~18 files) with a single `username` value.

- `mkHost` gains a `username ? "kronberger"` parameter, passed into `specialArgs` alongside the existing `host`/`isNotebook`/`primaryCompositor` knobs.
- The two hosts that bypass `mkHost` set it explicitly: `homeserver` (`"kronberger"`) and `mediaBox` (`"media"`, matching its `media` user).
- System modules now read `username`: `core/users.nix`, `core/nix-settings.nix` (`allowed-`/`trusted-users`, build-machine `sshUser`), `security/security.nix` (`AllowUsers`), `security/agenix.nix` (secret `owner`s), `services/syncthing.nix`, `services/virtualisation.nix`, `networking/pia.nix` + `networking/tuwien-vpn.nix` (sudo rules + polkit), and the per-host group/tmpfiles tweaks.
- Home-manager user modules mirror it into `home.username` / `home.homeDirectory`.
- Home-manager **personal paths** (`yazi`, `helix` `liveConfigPath`, `taskwarrior`) now use the canonical `config.home.homeDirectory` / `config.home.username` rather than literal `/home/kronberger`.

**Deliberately left untouched** (these contain `kronberger` but are *not* the local username): GitHub org `kronberger-droid`, email addresses, remote SSH build-host targets in nushell helpers, SSH key comments, the cachix cache name, agenix secret **names/filenames**, and the secondary `wiesinger` user on `homeserver`.

**Behavior note:** for the default `username = "kronberger"`, every resolved value is byte-identical to before. `helix.liveConfigPath`'s default now derives from `config.home.homeDirectory`, so under the `media` user it resolves to `/home/media/.config/nixos` instead of the previous `/home/kronberger/...` (which pointed at a home that doesn't exist on mediaBox) — in the direction of correctness; `droid` still overrides it to `null`.

## 2. Collapse agenix secret boilerplate

`modules/system/security/agenix.nix` repeated the same `file`/`path`/`mode` shape for every secret, differing only by name and owner. Replaced the hand-written block with a `mkSecret` helper applied over root-owned and user-owned name lists via `lib.genAttrs` (~45 lines removed). Resulting attrs are identical — same names, `/run/secrets/<name>` paths, `0400` mode, owners — and the per-secret format/usage comments are preserved on the list entries.

---

## Validation

⚠️ Prepared in an environment without `nix`, so **not** eval'd/built here. Please run `nix flake check` (or `nixos-rebuild build --flake .#<host>`) before merging. I verified that every module referencing `username` declares it as a function arg, that no host imports a parametrized module without supplying the value, and that all 10 agenix secret names are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)