### PR TITLE
fix(droid): guard XDG_RUNTIME_DIR read so nushell login shell starts

### DIFF
--- a/hosts/droid/home.nix
+++ b/hosts/droid/home.nix
@@ -3,10 +3,16 @@
   lib,
   pkgs,
   inputs,
+  stockNushell,
   ...
 }: {
   # Read the changelog before changing this value
   home.stateVersion = "24.05";
+
+  # Cached stock nushell — same package the login shell uses (see
+  # nix-on-droid.nix). Keeps the phone off the fork's on-device Rust build;
+  # nushell.nix sees the non-fork version string and falls back to vi edit-mode.
+  programs.nushell.package = stockNushell;
 
   # HM master tracks 26.11 while nixpkgs unstable is still 26.05; both follow
   # unstable here, so this is a false positive (same as the desktop config).

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -2,7 +2,18 @@
   pkgs,
   inputs,
   ...
-}: {
+}: let
+  # Stock nushell straight from nixpkgs, NOT the helix-mode fork
+  # (modules/shared/nushell-overlay.nix). The fork builds from source (Rust) and
+  # we deliberately keep the phone off any on-device compile, so use the prebuilt
+  # cache binary. Pulling it from inputs.nixpkgs.legacyPackages (rather than
+  # relying on "this host's pkgs happens to carry no nushell overlay") pins the
+  # cached build explicitly — it stays stock even if the overlay is ever added to
+  # this host's pkgs. nushell.nix detects the non-fork build via its version
+  # string and falls back to vi edit-mode automatically. The login shell below
+  # and home-manager's programs.nushell.package (home.nix) point at THIS package.
+  stockNushell = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.nushell;
+in {
   imports = [
     # Temporarily disabled: rust-overlay toolchain builds locally on-device and
     # is the prime suspect for the proot build-env pty/fd permission failure
@@ -36,8 +47,10 @@
     NIX_PATH = "";
   };
 
-  # Default login shell is nushell (configured via home-manager)
-  user.shell = "${pkgs.nushell}/bin/nu";
+  # Default login shell is nushell (configured via home-manager). Use the pinned
+  # cached build (see stockNushell above) so activation never triggers an
+  # on-device source rebuild.
+  user.shell = "${stockNushell}/bin/nu";
 
   # Read the changelog before changing this value
   system.stateVersion = "24.05";
@@ -78,6 +91,6 @@
     config = ./home.nix;
     backupFileExtension = "hm-bak";
     useGlobalPkgs = true;
-    extraSpecialArgs = {inherit inputs;};
+    extraSpecialArgs = {inherit inputs stockNushell;};
   };
 }

--- a/modules/home-manager/shell/nushell/extra_env.nu
+++ b/modules/home-manager/shell/nushell/extra_env.nu
@@ -1,5 +1,12 @@
-# SSH agent socket (oo7-ssh-agent via systemd socket activation)
-$env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/oo7-ssh-agent.sock"
+# SSH agent socket (oo7-ssh-agent via systemd socket activation). Only wire it
+# up where a runtime dir exists: reading `$env.XDG_RUNTIME_DIR` with the plain
+# `$env.NAME` form is a hard error in nushell when the var is unset, and hosts
+# without a systemd user session (nix-on-droid/Android) don't set it — that
+# error aborts env.nu at every startup, so the nushell login shell never comes
+# up. Guard with the optional `?` cell-path so those hosts just skip it.
+if ($env.XDG_RUNTIME_DIR? | is-not-empty) {
+    $env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/oo7-ssh-agent.sock"
+}
 
 # Force TTY passphrase prompts; suppress OpenSSH's bundled GUI askpass fallback
 $env.SSH_ASKPASS_REQUIRE = "never"


### PR DESCRIPTION
extra_env.nu set SSH_AUTH_SOCK from $env.XDG_RUNTIME_DIR unconditionally.
Reading an unset env var via the plain $env.NAME form is a hard
column_not_found error in nushell, and nix-on-droid/Android has no systemd
user session so XDG_RUNTIME_DIR is unset. The error aborts env.nu on every
startup, and since nushell is the login shell the nix-on-droid session never
comes up. Guard the read with the optional ? cell-path; desktop/server hosts
(which do set XDG_RUNTIME_DIR) keep wiring up the oo7-ssh-agent socket.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X7m5LoXP61G1fbCAhAEnfn