### PR TITLE
fix(droid): use bash login shell so nix-on-droid starts again

### DIFF
--- a/hosts/droid/home.nix
+++ b/hosts/droid/home.nix
@@ -9,10 +9,23 @@
   # Read the changelog before changing this value
   home.stateVersion = "24.05";
 
-  # Cached stock nushell — same package the login shell uses (see
-  # nix-on-droid.nix). Keeps the phone off the fork's on-device Rust build;
+  # Cached stock nushell — keeps the phone off the fork's on-device Rust build;
   # nushell.nix sees the non-fork version string and falls back to vi edit-mode.
   programs.nushell.package = stockNushell;
+
+  # bash is the nix-on-droid login shell (see user.shell in nix-on-droid.nix);
+  # it hands off to nushell for real interactive sessions. The `-t 0` guard is
+  # the crux: only exec nu when stdin is an actual TTY, so nu never hits its
+  # "STDIN is not a TTY" launch check that aborts the app at login. Non-TTY or
+  # script invocations (and the failsafe/rescue path) stay in plain bash.
+  programs.bash = {
+    enable = true;
+    initExtra = ''
+      if [[ $- == *i* ]] && [ -t 0 ]; then
+        exec ${stockNushell}/bin/nu
+      fi
+    '';
+  };
 
   # HM master tracks 26.11 while nixpkgs unstable is still 26.05; both follow
   # unstable here, so this is a false positive (same as the desktop config).

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -10,8 +10,8 @@
   # relying on "this host's pkgs happens to carry no nushell overlay") pins the
   # cached build explicitly — it stays stock even if the overlay is ever added to
   # this host's pkgs. nushell.nix detects the non-fork build via its version
-  # string and falls back to vi edit-mode automatically. The login shell below
-  # and home-manager's programs.nushell.package (home.nix) point at THIS package.
+  # string and falls back to vi edit-mode automatically. Used for both
+  # home-manager's programs.nushell.package and the bash->nu handoff (home.nix).
   stockNushell = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.nushell;
 in {
   imports = [
@@ -47,10 +47,13 @@ in {
     NIX_PATH = "";
   };
 
-  # Default login shell is nushell (configured via home-manager). Use the pinned
-  # cached build (see stockNushell above) so activation never triggers an
-  # on-device source rebuild.
-  user.shell = "${stockNushell}/bin/nu";
+  # Login shell is bash, NOT nushell directly. nushell is not a POSIX login
+  # shell: recent versions hard-abort with "Nushell launched as a REPL, but
+  # STDIN is not a TTY" when nix-on-droid execs them at login, which bricks the
+  # app on open. Bash logs in cleanly and hands off to nushell only once there's
+  # a real interactive TTY (see programs.bash.initExtra in home.nix), so nu
+  # inherits the terminal and starts fine. The interactive shell is still nu.
+  user.shell = "${pkgs.bash}/bin/bash";
 
   # Read the changelog before changing this value
   system.stateVersion = "24.05";


### PR DESCRIPTION
## Problem

The nix-on-droid image stopped starting after the last build, dying on open with:

```
Error:   × Nushell launched as a REPL, but STDIN is not a TTY; either launch in
  │ a valid terminal or provide arguments to invoke a script!
[Process completed (code 1)]
```

Recent nushell versions abort instead of starting a REPL when stdin is not a TTY ([nushell#9497](https://github.com/nushell/nushell/issues/9497)). nushell is not a POSIX login shell, and nix-on-droid execs `user.shell` at login in a way that trips that check ([nix-on-droid#22](https://github.com/t184256/nix-on-droid/issues/22)). Because the droid host runs *unpinned stock* nushell, the last `nix flake update` floated it up to a version with the check — which is why it broke "since the last build" while every other host (pinned fork) stayed fine.

## Fix

Make **bash** the login shell (it logs in cleanly) and hand off to nushell from `programs.bash.initExtra` only when the session is interactive **and** stdin is a real TTY (`[ -t 0 ]`). nushell then inherits the terminal and starts normally; non-TTY / script invocations and the failsafe/rescue path stay in bash. The interactive shell is still nushell.

No on-device build: stock cached nushell is fine once it gets a TTY.

## Notes

Follow-up to the merged #3, which already landed the `XDG_RUNTIME_DIR` guard and the explicit cached-nushell pin. This PR carries the remaining commit — the one that actually resolves the startup crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7m5LoXP61G1fbCAhAEnfn)_