### PR TITLE
fix(droid): run bash→nu handoff from the login profile too

### DIFF
--- a/hosts/droid/home.nix
+++ b/hosts/droid/home.nix
@@ -5,7 +5,16 @@
   inputs,
   stockNushell,
   ...
-}: {
+}: let
+  # Hand off from the bash login shell to nushell, but only for an interactive
+  # session on a real TTY — otherwise nu aborts with "STDIN is not a TTY". POSIX
+  # so it's safe in .profile as well as .bashrc.
+  nuHandoff = ''
+    case $- in
+      *i*) [ -t 0 ] && exec ${stockNushell}/bin/nu ;;
+    esac
+  '';
+in {
   # Read the changelog before changing this value
   home.stateVersion = "24.05";
 
@@ -18,13 +27,15 @@
   # the crux: only exec nu when stdin is an actual TTY, so nu never hits its
   # "STDIN is not a TTY" launch check that aborts the app at login. Non-TTY or
   # script invocations (and the failsafe/rescue path) stay in plain bash.
+  #
+  # Placed in BOTH profileExtra (.profile / .bash_profile — the login path
+  # nix-on-droid actually uses) and initExtra (.bashrc — non-login interactive).
+  # POSIX `case`/`[ -t 0 ]` so it's valid in .profile too; `exec` means whichever
+  # fires first wins and the other is never reached.
   programs.bash = {
     enable = true;
-    initExtra = ''
-      if [[ $- == *i* ]] && [ -t 0 ]; then
-        exec ${stockNushell}/bin/nu
-      fi
-    '';
+    profileExtra = nuHandoff;
+    initExtra = nuHandoff;
   };
 
   # HM master tracks 26.11 while nixpkgs unstable is still 26.05; both follow


### PR DESCRIPTION
## Problem

After the previous fix made bash the nix-on-droid login shell (merged in #4), the interactive session still landed in **bash** instead of handing off to nushell — you had to type `nu` manually.

Cause: the `exec nu` handoff only lived in `programs.bash.initExtra`, which home-manager writes to `~/.bashrc` — the *non-login* interactive file. nix-on-droid starts bash as a **login** shell, which reads the `.profile` / `.bash_profile` path, so `.bashrc`'s handoff never ran.

## Fix

Move the handoff into a shared POSIX snippet used in **both**:
- `programs.bash.profileExtra` → `.profile` / `.bash_profile` (the login path nix-on-droid actually uses)
- `programs.bash.initExtra` → `.bashrc` (non-login interactive)

It stays guarded on interactive **and** a real TTY (`case $- in *i*) [ -t 0 ] && exec … ;;`), so nushell is only exec'd when it can actually start — non-TTY, script, and rescue-shell paths remain in plain bash. `exec` means whichever file fires first wins and the other is a no-op.

## Notes

Follow-up to the merged #4. One commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7m5LoXP61G1fbCAhAEnfn)_