### PR TITLE
fix: stale oo7 flake follows + starship InstantOS warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,6 @@
     oo7-nixos = {
       url = "github:kronberger-droid/oo7-nixos";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.oo7-ssh-agent.inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     };
     lanzaboote = {
       url = "github:nix-community/lanzaboote";

--- a/modules/home-manager/shell/nushell.nix
+++ b/modules/home-manager/shell/nushell.nix
@@ -561,7 +561,22 @@ in {
 
     settings =
       lib.recursiveUpdate
-      (builtins.removeAttrs (builtins.fromTOML (builtins.readFile inputs.starship-nerd-fonts)) ["maven"])
+      (
+        let
+          preset = builtins.fromTOML (builtins.readFile inputs.starship-nerd-fonts);
+        in
+          # Strip entries our pinned starship is too old to parse (otherwise it
+          # warns on every prompt): `maven` (a module we don't use) and the
+          # `os.symbols.InstantOS` variant — starship master's preset carries it
+          # but our nixpkgs starship doesn't know it yet. If a later preset bump
+          # adds another unknown os variant, strip it here the same way.
+          (builtins.removeAttrs preset ["maven"])
+          // {
+            os = preset.os // {
+              symbols = builtins.removeAttrs preset.os.symbols ["InstantOS"];
+            };
+          }
+      )
       {
         command_timeout = 2000;
         # Single-line module row. `$all` is every module in default order, which


### PR DESCRIPTION
Two fixes surfaced while getting the nix-on-droid image booting again (follow-up to the merged #5).

## `fix(flake): drop stale oo7-ssh-agent rust-overlay follows`

`flake.nix` overrode `oo7-nixos → oo7-ssh-agent → rust-overlay → nixpkgs`, but `oo7-ssh-agent` no longer has a `rust-overlay` input (its lock node carries only `nixpkgs`). On a **cache-cold eval** — e.g. a fresh nix-on-droid install — Nix tries to resolve that dead override path and fails:

```
error: cannot find flake 'flake:oo7-ssh-agent' in the flake registries
```

(Warm-cache evals on existing machines never re-resolved it, so it went unnoticed.) The committed `flake.lock` already reflects `oo7-ssh-agent`-without-`rust-overlay`, so removing the line makes `flake.nix` consistent with the lock — no relock required.

## `fix(starship): strip os.symbols.InstantOS from nerd-font preset`

The nerd-font-symbols preset is fetched from starship `master`, which now carries an `os.symbols.InstantOS` variant our pinned nixpkgs starship doesn't recognize, so starship warned on every prompt. Dropped it the same way `maven` is already stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7m5LoXP61G1fbCAhAEnfn)_