### PR TITLE
fix(starship): bump nerd-font preset hash, drop os symbols

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -803,7 +803,7 @@
     "starship-nerd-fonts": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-ryCfz2m/9pab1tPRFa2zxnaEY3ghSA5VNqIIjSFj5Ww=",
+        "narHash": "sha256-8KGG/K3WkSA1JR+BfkegVbSGiH5ZdyvWQgaV/oV4MPE=",
         "type": "file",
         "url": "https://raw.githubusercontent.com/starship/starship/master/docs/public/presets/toml/nerd-font-symbols.toml"
       },

--- a/modules/home-manager/shell/nushell.nix
+++ b/modules/home-manager/shell/nushell.nix
@@ -561,22 +561,13 @@ in {
 
     settings =
       lib.recursiveUpdate
-      (
-        let
-          preset = builtins.fromTOML (builtins.readFile inputs.starship-nerd-fonts);
-        in
-          # Strip entries our pinned starship is too old to parse (otherwise it
-          # warns on every prompt): `maven` (a module we don't use) and the
-          # `os.symbols.InstantOS` variant — starship master's preset carries it
-          # but our nixpkgs starship doesn't know it yet. If a later preset bump
-          # adds another unknown os variant, strip it here the same way.
-          (builtins.removeAttrs preset ["maven"])
-          // {
-            os = preset.os // {
-              symbols = builtins.removeAttrs preset.os.symbols ["InstantOS"];
-            };
-          }
-      )
+      # Nerd-font symbols preset from starship master (via inputs.starship-nerd-fonts;
+      # bump its narHash in flake.lock when upstream edits the file). Drop `maven`
+      # (a module we don't use) and the whole `os` table: starship master keeps
+      # adding os.symbols variants (InstantOS, Bazzite, …) that our pinned starship
+      # doesn't know yet, and each unknown one makes it warn on every prompt. The
+      # os module is off by default, so dropping its symbols costs nothing visible.
+      (builtins.removeAttrs (builtins.fromTOML (builtins.readFile inputs.starship-nerd-fonts)) ["maven" "os"])
       {
         command_timeout = 2000;
         # Single-line module row. `$all` is every module in default order, which


### PR DESCRIPTION
Follow-up to #6, which merged an incomplete starship fix — `main` still fails cache-cold because the lock hash was never updated.

## Problem

`starship-nerd-fonts` is a raw URL on starship's **master** branch (mutable). Upstream edited the preset, so its NAR hash no longer matches `flake.lock`:

```
error: NAR hash mismatch in input '…/nerd-font-symbols.toml'
  expected 'sha256-ryCfz2m/9pab1tPRFa2zxnaEY3ghSA5VNqIIjSFj5Ww='
  got      'sha256-8KGG/K3WkSA1JR+BfkegVbSGiH5ZdyvWQgaV/oV4MPE='
```

Any cache-cold eval (fresh nix-on-droid install) hits this before starship config is even parsed.

## Fix

- **Bump the locked `narHash`** for `starship-nerd-fonts` to the current upstream content.
- **Strip the whole `os` table** from the preset (in addition to `maven`), replacing the earlier InstantOS-only strip. Starship master keeps adding `os.symbols` variants (`InstantOS`, `Bazzite`, `Hurd`, `KDENeon`, `PikaOS`, …) that the pinned nixpkgs starship rejects, warning on every prompt. The `os` module is disabled by default, so dropping its symbols has no visible effect — and it needs no per-variant maintenance.

All other nerd-font glyphs are unchanged. When upstream edits the preset again and a cache-cold build fails, the only maintenance is bumping this one `narHash` (or `nix flake update starship-nerd-fonts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7m5LoXP61G1fbCAhAEnfn)_