### PR TITLE
fix(droid): install user packages with nix-env --set, not --install

### DIFF
--- a/hosts/droid/home.nix
+++ b/hosts/droid/home.nix
@@ -9,10 +9,22 @@
   # Hand off from the bash login shell to nushell, but only for an interactive
   # session on a real TTY — otherwise nu aborts with "STDIN is not a TTY". POSIX
   # so it's safe in .profile as well as .bashrc.
+  #
+  # When the handoff does NOT fire, say why on stderr: a silent landing in
+  # bare bash is undebuggable from the phone, and the reason (no TTY vs. shell
+  # not interactive) points at completely different culprits. Set NO_NU=1 to
+  # skip the handoff (and the breadcrumb) and get plain bash on purpose.
   nuHandoff = ''
-    case $- in
-      *i*) [ -t 0 ] && exec ${stockNushell}/bin/nu ;;
-    esac
+    if [ -z "''${NO_NU:-}" ]; then
+      if [ -t 0 ]; then
+        case $- in
+          *i*) exec ${stockNushell}/bin/nu ;;
+        esac
+        echo "[droid] staying in bash: TTY stdin but shell is not interactive (\$0=$0, \$-=$-)" >&2
+      else
+        echo "[droid] staying in bash: stdin is not a TTY (stdin -> $(readlink /proc/$$/fd/0 2>/dev/null || echo unknown)); nu needs a TTY" >&2
+      fi
+    fi
   '';
 in {
   # Read the changelog before changing this value

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -74,6 +74,20 @@ in {
 
   nix.extraOptions = ''
     experimental-features = nix-command flakes
+
+    # Never build on-device: proot on this phone denies the pseudoterminal
+    # Nix allocates for every local builder ("getting pseudoterminal
+    # attributes: Permission denied"), so ALL builds are pushed to the
+    # homeserver (aarch64 via binfmt emulation; kronberger is a trusted-user
+    # there via modules/system/core/nix-settings.nix). max-jobs = 0 forces
+    # remote building even though the builder's system matches ours.
+    # Requires ~/.ssh/id_ed25519 (authorized on the homeserver) and its host
+    # key in known_hosts. 192.168.2.54 = LAN; use 100.92.46.97 when on
+    # tailscale away from home. Trade-off: switching needs the homeserver
+    # reachable — acceptable, since local builds cannot work at all.
+    builders = ssh://kronberger@192.168.2.54 aarch64-linux
+    builders-use-substitutes = true
+    max-jobs = 0
   '';
 
   # Terminal colors (based on the Kitty config)

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -48,7 +48,7 @@ in {
   environment.etcBackupExtension = ".bak";
 
   environment.sessionVariables = {
-    SHELL = "${pkgs.bash}/bin/bash";
+    SHELL = "${pkgs.bashInteractive}/bin/bash";
     # Disable channels warning since we're using flakes
     NIX_PATH = "";
   };
@@ -59,7 +59,10 @@ in {
   # app on open. Bash logs in cleanly and hands off to nushell only once there's
   # a real interactive TTY (see programs.bash.initExtra in home.nix), so nu
   # inherits the terminal and starts fine. The interactive shell is still nu.
-  user.shell = "${pkgs.bash}/bin/bash";
+  # bashInteractive, not pkgs.bash: nixpkgs' plain bash is the minimal build
+  # without readline — as a login shell it gives a degraded, editing-less
+  # prompt. bashInteractive is the full build (and what nix-on-droid ships).
+  user.shell = "${pkgs.bashInteractive}/bin/bash";
 
   # Read the changelog before changing this value
   system.stateVersion = "24.05";

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -15,6 +15,12 @@
   stockNushell = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.nushell;
 in {
   imports = [
+    # Replaces upstream's installPackages activation (nix-env --install) with
+    # a build-free `nix-env --set` — proot on this device cannot allocate the
+    # builder pty that the on-device user-environment build needs, which
+    # aborted every switch before home-manager activation. See file header.
+    ./user-environment.nix
+
     # Temporarily disabled: rust-overlay toolchain builds locally on-device and
     # is the prime suspect for the proot build-env pty/fd permission failure
     # during `nix-on-droid switch`. Re-enable once the switch succeeds without it.

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -21,6 +21,11 @@ in {
     # aborted every switch before home-manager activation. See file header.
     ./user-environment.nix
 
+    # Pins proot-static back to unstable-2023-11-11: the 2024-05-04 build
+    # upstream ships breaks ALL local derivation builds on this device with
+    # the same pseudoterminal error. See file header.
+    ./proot-pin.nix
+
     # Temporarily disabled: rust-overlay toolchain builds locally on-device and
     # is the prime suspect for the proot build-env pty/fd permission failure
     # during `nix-on-droid switch`. Re-enable once the switch succeeds without it.

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -82,10 +82,12 @@ in {
     # there via modules/system/core/nix-settings.nix). max-jobs = 0 forces
     # remote building even though the builder's system matches ours.
     # Requires ~/.ssh/id_ed25519 (authorized on the homeserver) and its host
-    # key in known_hosts. 192.168.2.54 = LAN; use 100.92.46.97 when on
-    # tailscale away from home. Trade-off: switching needs the homeserver
+    # key in known_hosts. Both routes to the homeserver are listed — tailscale
+    # (100.92.46.97, works from anywhere while the Tailscale app is connected)
+    # first, home LAN (192.168.2.54) as fallback; nix skips an unreachable
+    # builder and tries the next. Trade-off: switching needs the homeserver
     # reachable — acceptable, since local builds cannot work at all.
-    builders = ssh://kronberger@192.168.2.54 aarch64-linux
+    builders = ssh://kronberger@100.92.46.97 aarch64-linux ; ssh://kronberger@192.168.2.54 aarch64-linux
     builders-use-substitutes = true
     max-jobs = 0
   '';

--- a/hosts/droid/proot-pin.nix
+++ b/hosts/droid/proot-pin.nix
@@ -62,7 +62,12 @@ in {
       };
 
       prootStatic = mkOption {
-        type = types.package;
+        # types.str, not upstream's types.package: the package type coerces
+        # the raw store-path string through builtins.storePath, which requires
+        # --impure AND the path to be valid in the local store at eval time.
+        # As a plain string the path only has to exist once the activation
+        # script's realise guard has substituted it.
+        type = types.str;
         readOnly = true;
         internal = true;
         description = "<literal>proot-static</literal> package.";

--- a/hosts/droid/proot-pin.nix
+++ b/hosts/droid/proot-pin.nix
@@ -1,0 +1,128 @@
+# Vendored & patched copy of nix-on-droid's modules/environment/login
+# (rev 55b6449b, the flake.lock pin), swapped in via disabledModules below.
+# login.nix / login-inner.nix are reused from the input unchanged; only this
+# default.nix is replicated, to change which proot-static gets installed.
+#
+# Why: upstream pins proot-termux unstable-2024-05-04. On this phone that
+# build cannot allocate build pseudoterminals — every local derivation build
+# dies with "error: getting pseudoterminal attributes: Permission denied"
+# (tcgetattr on the pty master in Nix's builder setup). The device ran an
+# older proot for months (the installProotStatic activation step is ordered
+# AFTER installPackages, which always failed, so the 2024-05-04 binary was
+# never installed) and local builds worked the whole time. The first switch
+# that got past installPackages staged the new proot; the next app restart
+# swapped it in, and from then on even trivial writeText derivations failed
+# to build. Pin the previous proot (unstable-2023-11-11, what nix-on-droid
+# shipped before commit 35076ea) to get building working again.
+#
+# The store path is substituted from https://nix-on-droid.cachix.org (a
+# default substituter on-device) before the copy, since these cross-compiled
+# paths are referenced by string and are not part of the generation closure.
+#
+# Drop this file (and its import in nix-on-droid.nix) if a future
+# nix-on-droid pin ships a proot that handles build ptys on this device.
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  initialPackageInfo,
+  targetSystem,
+  ...
+}:
+with lib; let
+  cfg = config.environment.files;
+
+  loginDir = "${inputs.nix-on-droid}/modules/environment/login";
+
+  login = pkgs.callPackage "${loginDir}/login.nix" {inherit config;};
+
+  loginInner = pkgs.callPackage "${loginDir}/login-inner.nix" {
+    inherit config initialPackageInfo targetSystem;
+  };
+in {
+  disabledModules = [loginDir "${loginDir}/default.nix"];
+
+  ###### interface (upstream-verbatim)
+
+  options = {
+    environment.files = {
+      login = mkOption {
+        type = types.package;
+        readOnly = true;
+        internal = true;
+        description = "Login script.";
+      };
+
+      loginInner = mkOption {
+        type = types.package;
+        readOnly = true;
+        internal = true;
+        description = "Login-inner script.";
+      };
+
+      prootStatic = mkOption {
+        type = types.package;
+        readOnly = true;
+        internal = true;
+        description = "<literal>proot-static</literal> package.";
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = {
+    build.activation = {
+      # upstream-verbatim
+      installLogin = ''
+        if ! diff /bin/login ${login} > /dev/null; then
+          $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents /bin
+          $DRY_RUN_CMD cp $VERBOSE_ARG ${login} /bin/.login.tmp
+          $DRY_RUN_CMD chmod $VERBOSE_ARG u+w /bin/.login.tmp
+          $DRY_RUN_CMD mv $VERBOSE_ARG /bin/.login.tmp /bin/login
+        fi
+      '';
+
+      # upstream-verbatim
+      installLoginInner = ''
+        if (test -e /usr/lib/.login-inner.new && ! diff /usr/lib/.login-inner.new ${loginInner} > /dev/null) || \
+            (! test -e /usr/lib/.login-inner.new && ! diff /usr/lib/login-inner ${loginInner} > /dev/null); then
+          $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents /usr/lib
+          $DRY_RUN_CMD cp $VERBOSE_ARG ${loginInner} /usr/lib/.login-inner.tmp
+          $DRY_RUN_CMD chmod $VERBOSE_ARG u+w /usr/lib/.login-inner.tmp
+          $DRY_RUN_CMD mv $VERBOSE_ARG /usr/lib/.login-inner.tmp /usr/lib/.login-inner.new
+        fi
+      '';
+
+      # upstream-verbatim except the substitution guard: the pinned proot is
+      # referenced by string (no store context), so make sure it exists in the
+      # local store before copying from it.
+      installProotStatic = ''
+        if ! test -e ${cfg.prootStatic}/bin/proot-static; then
+          $DRY_RUN_CMD nix-store --realise ${cfg.prootStatic} > /dev/null
+        fi
+        if (test -e /bin/.proot-static.new && ! diff /bin/.proot-static.new ${cfg.prootStatic}/bin/proot-static > /dev/null) || \
+            (! test -e /bin/.proot-static.new && ! diff /bin/proot-static ${cfg.prootStatic}/bin/proot-static > /dev/null); then
+          $DRY_RUN_CMD mkdir $VERBOSE_ARG --parents /bin
+          $DRY_RUN_CMD cp $VERBOSE_ARG ${cfg.prootStatic}/bin/proot-static /bin/.proot-static.tmp
+          $DRY_RUN_CMD chmod $VERBOSE_ARG u+w /bin/.proot-static.tmp
+          $DRY_RUN_CMD mv $VERBOSE_ARG /bin/.proot-static.tmp /bin/.proot-static.new
+        fi
+      '';
+    };
+
+    environment.files = {
+      inherit login loginInner;
+
+      # unstable-2023-11-11, the pin upstream used before 2024-05-04 — the
+      # last proot known to handle Nix build ptys on this device.
+      prootStatic = let
+        crossCompiledPaths = {
+          aarch64-linux = "/nix/store/phj07a1pg3vwqdhq4cxd1dac4zc28mnc-proot-termux-static-aarch64-unknown-linux-android-unstable-2023-11-11";
+          x86_64-linux = "/nix/store/kg1bfwprdlf28fqd7ml86fywshkvcbhl-proot-termux-static-x86_64-unknown-linux-android-unstable-2023-11-11";
+        };
+      in "${crossCompiledPaths.${targetSystem}}";
+    };
+  };
+}

--- a/hosts/droid/user-environment.nix
+++ b/hosts/droid/user-environment.nix
@@ -1,0 +1,117 @@
+# Vendored & patched copy of nix-on-droid's modules/environment/path.nix
+# (rev 55b6449b, the flake.lock pin), swapped in via disabledModules below.
+#
+# Why: upstream's installPackages activation runs `nix-env --install`, which
+# instantiates and BUILDS a fresh user-environment derivation on-device at
+# activation time. proot on this phone denies the builder's pseudoterminal
+# ("error: getting pseudoterminal attributes: Permission denied", see
+# nix-on-droid#423), so that build can never succeed — and because the
+# activation script is `set -e`, the switch dies there, before the
+# home-manager step in activationAfter ever runs. Net effect: bare bash
+# login with none of the HM dotfiles (no bash->nu handoff, no config).
+#
+# Fix: environment.path is already a buildEnv of environment.packages and is
+# realised during the *build* phase of `nix-on-droid switch` (it is part of
+# the generation closure — activation.nix symlinks it into the generation),
+# and that phase works fine under proot. `nix-env --set` points the profile
+# generation directly at that pre-built path without building anything, so
+# the pty is never allocated. The profile tree it produces is equivalent to
+# what `nix-env --install` built (the buildEnv contents), minus the
+# manifest.nix — which nix-on-droid never consults, since every switch
+# re-sets the whole profile anyway.
+#
+# This replacement is needed (rather than a plain option override) because
+# build.activation is types.attrs: last definition wins and upstream's
+# modules are evaluated after this config, so a user-level redefinition of
+# build.activation.installPackages silently loses. Everything except the
+# nix-env branch is upstream-verbatim; drop this file and its import if
+# upstream fixes #423.
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+with lib; let
+  cfg = config.environment;
+in {
+  disabledModules = ["${inputs.nix-on-droid}/modules/environment/path.nix"];
+
+  ###### interface (upstream-verbatim)
+
+  options = {
+    environment = {
+      packages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = "List of packages to be installed as user packages.";
+      };
+
+      path = mkOption {
+        type = types.package;
+        readOnly = true;
+        internal = true;
+        description = "Derivation for installing user packages.";
+      };
+
+      extraOutputsToInstall = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ["doc" "info" "devdoc"];
+        description = "List of additional package outputs to be installed as user packages.";
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = {
+    build.activation.installPackages = ''
+      if [[ -e "${config.user.home}/.nix-profile/manifest.json" ]]; then
+        # New-style profile: `nix profile` materialises the env client-side
+        # (no builder process, no pty), so upstream's logic is kept as-is.
+        # manual removal and installation as two non-atomical steps is required
+        # because of https://github.com/NixOS/nix/issues/6349
+
+        nix_previous="$(command -v nix)"
+
+        nix profile list \
+          | grep 'nix-on-droid-path$' \
+          | cut -d ' ' -f 4 \
+          | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+
+        $DRY_RUN_CMD $nix_previous profile install ${cfg.path}
+
+        unset nix_previous
+      else
+        # Legacy profile: --set instead of upstream's --install, so nothing
+        # is built on-device (see header comment for the proot pty story).
+        $DRY_RUN_CMD nix-env --set ${cfg.path}
+      fi
+    '';
+
+    environment = {
+      packages = [
+        (pkgs.callPackage "${inputs.nix-on-droid}/nix-on-droid" {nix = config.nix.package;})
+        pkgs.bashInteractive
+        pkgs.cacert
+        pkgs.coreutils
+        pkgs.less # since nix tools really want a pager available, #27
+        config.nix.package
+      ];
+
+      path = pkgs.buildEnv {
+        name = "nix-on-droid-path";
+
+        paths = cfg.packages;
+
+        inherit (cfg) extraOutputsToInstall;
+
+        meta = {
+          description = "Environment of packages installed through Nix-on-Droid.";
+        };
+      };
+    };
+  };
+}

--- a/hosts/homeserver/configuration.nix
+++ b/hosts/homeserver/configuration.nix
@@ -40,6 +40,11 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # aarch64 emulation so this host can act as remote builder for the phone's
+  # nix-on-droid config (proot on the phone cannot allocate build ptys, so the
+  # droid config points its `builders` here and never builds locally).
+  boot.binfmt.emulatedSystems = ["aarch64-linux"];
+
   # Networking
   networking = {
     hostName = "homeserver";


### PR DESCRIPTION
nix-env --install builds a fresh user-environment derivation on-device at
activation time, and proot on this phone denies the builder's pty
("getting pseudoterminal attributes: Permission denied", nix-on-droid#423).
The activation script is set -e, so every switch died at installPackages —
before the home-manager step in activationAfter — leaving a bare bash login
with no HM dotfiles and no bash->nu handoff.

environment.path is already a buildEnv realised during the switch's build
phase (it is symlinked into the generation), so point the profile at it
with nix-env --set instead: zero on-device builds, no pty allocated.

build.activation is types.attrs (last definition wins, upstream evaluates
after user config), so a plain override loses silently; vendor upstream's
modules/environment/path.nix via disabledModules with only the nix-env
branch changed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BAFKxdMjoZnd5WRqMMtrNP