### PR TITLE
fix(droid): start nushell via /dev/tty, strip fork-only keybinding modes on stock nushell

### DIFF
--- a/hosts/droid/home.nix
+++ b/hosts/droid/home.nix
@@ -22,7 +22,23 @@
         esac
         echo "[droid] staying in bash: TTY stdin but shell is not interactive (\$0=$0, \$-=$-)" >&2
       else
-        echo "[droid] staying in bash: stdin is not a TTY (stdin -> $(readlink /proc/$$/fd/0 2>/dev/null || echo unknown)); nu needs a TTY" >&2
+        # SELinux in the nix-on-droid app denies terminal ioctls on the
+        # INHERITED stdin fd (isatty -> EACCES) while a freshly opened
+        # /dev/tty works fine — helix (crossterm) relies on exactly that.
+        # So for the app's login shell ($0 = "-bash"; plain `bash -l -c cmd`
+        # keeps $0 = "bash" and is never hijacked), hand nu fds opened from
+        # /dev/tty. Deliberately NOT exec: if nu still cannot start, we fall
+        # back to bash with a breadcrumb instead of ending the session —
+        # nu aborting at startup is what bricked app launch originally.
+        if [ -z "''${_NU_TRIED:-}" ] && ( : < /dev/tty ) 2>/dev/null; then
+          case $0 in
+            -*)
+              export _NU_TRIED=1
+              ${stockNushell}/bin/nu < /dev/tty > /dev/tty 2>&1 && exit
+              ;;
+          esac
+        fi
+        echo "[droid] staying in bash: stdin is not a TTY (stdin -> $(readlink /proc/$$/fd/0 2>/dev/null || echo unknown)) and the /dev/tty handoff did not stick" >&2
       fi
     fi
   '';

--- a/modules/home-manager/shell/nushell.nix
+++ b/modules/home-manager/shell/nushell.nix
@@ -22,7 +22,21 @@ in {
     navi
   ];
 
-  xdg.configFile."nushell/keybindings.nu".source = ./nushell/keybindings.nu;
+  # Same fork detection as the edit_mode injection in extraConfig below:
+  # stock nushell hard-errors at startup on the fork-only helix_* keybinding
+  # modes ("expected 'emacs', 'vi_insert', or 'vi_normal'"), so strip them
+  # from the mode lists when running the prebuilt stock package (droid,
+  # mediaBox).
+  xdg.configFile."nushell/keybindings.nu".text = let
+    src = builtins.readFile ./nushell/keybindings.nu;
+  in
+    if lib.hasInfix "helix" (config.programs.nushell.package.version or "")
+    then src
+    else
+      builtins.replaceStrings
+      ["[helix_insert helix_normal vi_insert vi_normal]"]
+      ["[vi_insert vi_normal]"]
+      src;
 
   # Generated so it can use centralised path variables
   xdg.configFile."nushell/utilities.nu".text = ''

--- a/modules/home-manager/shell/nushell/keybindings.nu
+++ b/modules/home-manager/shell/nushell/keybindings.nu
@@ -5,6 +5,11 @@
 # the real reedline Helix edit mode (edit_mode = 'helix'), which implements that
 # behaviour in the engine. What remains are genuine nushell bindings; they
 # target helix modes (and vi, so they survive a switch back to edit_mode 'vi').
+#
+# NOTE: keep mode lists written EXACTLY as
+# `[helix_insert helix_normal vi_insert vi_normal]` — nushell.nix rewrites
+# that literal to `[vi_insert vi_normal]` for stock-nushell hosts, where the
+# fork-only helix_* modes are a startup error.
 
 export def get_keybindings [] {
     [


### PR DESCRIPTION
Follow-up to #8 — the two fixes that make nushell actually start in the nix-on-droid app.

## What

- **`/dev/tty` handoff** (`hosts/droid/home.nix`): on this device, SELinux denies terminal ioctls on the *inherited* stdin fd inside the nix-on-droid app (`stty` → `Permission denied`, `[ -t 0 ]` false), while a freshly opened `/dev/tty` works — helix (crossterm) already relies on that. The bash→nu handoff now starts nu with all three fds redirected from `/dev/tty` when the inherited stdin fails the TTY check. Deliberately **not** `exec`'d: if nu can't start, the session falls back to bash with a diagnostic breadcrumb instead of dying at app launch (a nu startup abort is what originally bricked the app).
- **Stock-nushell keybindings** (`modules/home-manager/shell/nushell.nix`, `keybindings.nu`): stock nushell hard-errors at startup on the fork-only `helix_insert`/`helix_normal` keybinding modes. The mode list is now rewritten to `[vi_insert vi_normal]` nix-side for hosts on the prebuilt stock package (droid, mediaBox), mirroring the existing `edit_mode` fork detection. Fork hosts are byte-identical to before.

## Verified

- `nu < /dev/tty > /dev/tty 2>&1` confirmed working on-device (nushell prompt reached); the keybindings error seen there is what the second commit fixes.
- The rewritten keybindings output was eval-checked to contain `mode: [vi_insert vi_normal]` and no `helix_*` modes for stock builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAFKxdMjoZnd5WRqMMtrNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAFKxdMjoZnd5WRqMMtrNP)_