### PR TITLE
feat(droid): switch nushell to the helix-mode-wip fork

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -345,6 +345,12 @@
         overlays = [
           inputs.nix-on-droid.overlays.default
           inputs.rust-overlay.overlays.default
+          # Same Helix-mode nushell fork as every other host. Previously
+          # droid stayed on stock nixpkgs nushell to avoid an on-device Rust
+          # build, but the homeserver (which builds this same overlay) is
+          # already droid's remote builder/substituter, so it hands back the
+          # prebuilt output instead of compiling on the phone.
+          (import ./modules/shared/nushell-overlay.nix inputs)
           (_: _: {
             claude-code-bin = inputs.claude-code.packages.${armSystem}.claude-code;
           })

--- a/hosts/droid/home.nix
+++ b/hosts/droid/home.nix
@@ -3,7 +3,6 @@
   lib,
   pkgs,
   inputs,
-  stockNushell,
   ...
 }: let
   # Hand off from the bash login shell to nushell, but only for an interactive
@@ -18,7 +17,7 @@
     if [ -z "''${NO_NU:-}" ]; then
       if [ -t 0 ]; then
         case $- in
-          *i*) exec ${stockNushell}/bin/nu ;;
+          *i*) exec ${pkgs.nushell}/bin/nu ;;
         esac
         echo "[droid] staying in bash: TTY stdin but shell is not interactive (\$0=$0, \$-=$-)" >&2
       else
@@ -34,7 +33,7 @@
           case $0 in
             -*)
               export _NU_TRIED=1
-              ${stockNushell}/bin/nu < /dev/tty > /dev/tty 2>&1 && exit
+              ${pkgs.nushell}/bin/nu < /dev/tty > /dev/tty 2>&1 && exit
               ;;
           esac
         fi
@@ -45,10 +44,6 @@
 in {
   # Read the changelog before changing this value
   home.stateVersion = "24.05";
-
-  # Cached stock nushell — keeps the phone off the fork's on-device Rust build;
-  # nushell.nix sees the non-fork version string and falls back to vi edit-mode.
-  programs.nushell.package = stockNushell;
 
   # bash is the nix-on-droid login shell (see user.shell in nix-on-droid.nix);
   # it hands off to nushell for real interactive sessions. The `-t 0` guard is

--- a/hosts/droid/nix-on-droid.nix
+++ b/hosts/droid/nix-on-droid.nix
@@ -2,18 +2,7 @@
   pkgs,
   inputs,
   ...
-}: let
-  # Stock nushell straight from nixpkgs, NOT the helix-mode fork
-  # (modules/shared/nushell-overlay.nix). The fork builds from source (Rust) and
-  # we deliberately keep the phone off any on-device compile, so use the prebuilt
-  # cache binary. Pulling it from inputs.nixpkgs.legacyPackages (rather than
-  # relying on "this host's pkgs happens to carry no nushell overlay") pins the
-  # cached build explicitly — it stays stock even if the overlay is ever added to
-  # this host's pkgs. nushell.nix detects the non-fork build via its version
-  # string and falls back to vi edit-mode automatically. Used for both
-  # home-manager's programs.nushell.package and the bash->nu handoff (home.nix).
-  stockNushell = inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system}.nushell;
-in {
+}: {
   imports = [
     # Replaces upstream's installPackages activation (nix-env --install) with
     # a build-free `nix-env --set` — proot on this device cannot allocate the
@@ -124,6 +113,6 @@ in {
     config = ./home.nix;
     backupFileExtension = "hm-bak";
     useGlobalPkgs = true;
-    extraSpecialArgs = {inherit inputs stockNushell;};
+    extraSpecialArgs = {inherit inputs;};
   };
 }

--- a/modules/home-manager/shell/nushell.nix
+++ b/modules/home-manager/shell/nushell.nix
@@ -25,8 +25,7 @@ in {
   # Same fork detection as the edit_mode injection in extraConfig below:
   # stock nushell hard-errors at startup on the fork-only helix_* keybinding
   # modes ("expected 'emacs', 'vi_insert', or 'vi_normal'"), so strip them
-  # from the mode lists when running the prebuilt stock package (droid,
-  # mediaBox).
+  # from the mode lists when running the prebuilt stock package (mediaBox).
   xdg.configFile."nushell/keybindings.nu".text = let
     src = builtins.readFile ./nushell/keybindings.nu;
   in


### PR DESCRIPTION
## Summary
- Droid previously pinned stock nixpkgs nushell to avoid an on-device Rust build. It now uses the same `helix-mode-wip` fork overlay as every other host, since the homeserver (droid's remote builder) already builds this overlay and hands back the prebuilt output via substitution instead of compiling on the phone.
- Removed the `stockNushell` special-casing in `hosts/droid/nix-on-droid.nix` and `hosts/droid/home.nix` (bash→nu handoff now execs `${pkgs.nushell}/bin/nu`, `programs.nushell.package` override dropped).
- Added the shared `modules/shared/nushell-overlay.nix` to droid's `nixOnDroidConfigurations` overlays in `flake.nix`.
- The existing fork-detection in `modules/home-manager/shell/nushell.nix` (checks for `"helix"` in the package version string) automatically enables `edit_mode = 'helix'`, the helix cursor shapes, and the fork-only keybindings for droid — no extra changes needed there beyond fixing a stale comment.

## Test plan
- [ ] Run `nh os switch`/`nix-on-droid switch` on the actual droid device to confirm the fork build substitutes from the homeserver instead of compiling on-device
- [ ] Confirm `nu` starts with helix edit mode and keybindings active on droid


---
_Generated by [Claude Code](https://claude.ai/code/session_01XLz86ZQvuYBBabGhyAffLp)_